### PR TITLE
Changed the anchors to use titles instead of paragraph ids

### DIFF
--- a/jumplink.info.yml
+++ b/jumplink.info.yml
@@ -2,4 +2,6 @@ name: 'jumplink'
 type: module
 description: 'A Drupal 8 Module which allows editors to create jumplinks without needing to set classes and anchors.'
 core: 8.x
+dependencies:
+  - paragraphs
 package: 'Jump Links'

--- a/jumplink.module
+++ b/jumplink.module
@@ -28,7 +28,7 @@ function jumplink_help($route_name, RouteMatchInterface $route_match) {
  */
 function jumplink_theme() {
   return [
-    'page__some__core_paragraph' => [ //some core paragraph twig file that you will want to override.
+    'page__some__core_paragraph' => [ //paragraph twig file that you want to override.
       'template' => 'some--template-file-paragraph' //files is a .twig file
     ],
   ];


### PR DESCRIPTION
I changed the way in which the anchors are generated within the block instead of using #paragraph-id now they use the title specified on the paragraph itself.

I also cleaned the code a little bit to comply with Drupal code standards and added paragraphs as a module dependency for this module